### PR TITLE
feat(notify): 支持 Bark 推送，可按任务开关并在输出变动时通知

### DIFF
--- a/Sources/Engine/BarkPushManager.swift
+++ b/Sources/Engine/BarkPushManager.swift
@@ -1,0 +1,173 @@
+import CryptoKit
+import Foundation
+import TaskTickCore
+
+/// Sends task-completion pushes to a user-configured Bark endpoint.
+///
+/// Architecture mirrors `NotificationManager`: one shared sender, fire-and-forget
+/// from `ScriptExecutor`. The device URL lives in app Settings (`barkServerURL`);
+/// each task opts in via `ScheduledTask.barkPushEnabled`. An empty / invalid URL
+/// disables Bark globally without touching the per-task switches.
+final class BarkPushManager: @unchecked Sendable {
+
+    static let shared = BarkPushManager()
+    static let urlDefaultsKey = "barkServerURL"
+
+    private init() {}
+
+    // MARK: - URL
+
+    /// Accepts the URL copied from the Bark app (`https://api.day.app/<key>/`)
+    /// or a bare device key. Trailing slashes are stripped; query items kept.
+    static func normalizedURL(from raw: String) -> URL? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let candidate: String
+        if let scheme = URL(string: trimmed)?.scheme?.lowercased(),
+           scheme == "http" || scheme == "https" {
+            candidate = trimmed
+        } else if trimmed.contains("://") {
+            return nil
+        } else {
+            let key = trimmed.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            guard key.range(of: "^[A-Za-z0-9_-]+$", options: .regularExpression) != nil else {
+                return nil
+            }
+            candidate = "https://api.day.app/\(key)"
+        }
+
+        guard var components = URLComponents(string: candidate) else { return nil }
+        guard let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = components.host, !host.isEmpty
+        else { return nil }
+
+        while components.path.hasSuffix("/") && components.path.count > 1 {
+            components.path.removeLast()
+        }
+        // Official Bark URLs always carry the device key as the first path
+        // component. A host-only URL (https://api.day.app) cannot push.
+        if components.path.isEmpty || components.path == "/" {
+            return nil
+        }
+        return components.url
+    }
+
+    static func isConfigured(_ defaults: UserDefaults = .standard) -> Bool {
+        let raw = defaults.string(forKey: urlDefaultsKey) ?? ""
+        return normalizedURL(from: raw) != nil
+    }
+
+    // MARK: - Output change
+
+    /// Stable fingerprint of the script's "output content".
+    /// Prefers trimmed stdout; falls back to stderr when stdout is empty so
+    /// failed runs still de-dupe on the error text.
+    static func outputFingerprint(stdout: String, stderr: String) -> String {
+        let out = stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        let err = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        let payload = out.isEmpty ? err : out
+        let digest = SHA256.hash(data: Data(payload.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// First run (`previous == nil`) always notifies. Later runs notify only
+    /// when the fingerprint changed.
+    static func shouldNotifyOnOutputChange(previousFingerprint: String?, currentFingerprint: String) -> Bool {
+        previousFingerprint != currentFingerprint
+    }
+
+    // MARK: - Send
+
+    /// Fire-and-forget push used after a task finishes.
+    func send(title: String, body: String, defaults: UserDefaults = .standard) {
+        let rawURL = defaults.string(forKey: Self.urlDefaultsKey) ?? ""
+        Task {
+            let result = await post(title: title, body: body, rawURL: rawURL)
+            if case .failure(let error) = result {
+                NSLog("⚠️ Bark push failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Settings "Send Test" — waits for the HTTP response so the UI can report it.
+    func sendTest(defaults: UserDefaults = .standard) async -> Result<Void, BarkPushError> {
+        let rawURL = defaults.string(forKey: Self.urlDefaultsKey) ?? ""
+        return await post(
+            title: L10n.tr("settings.bark.test.title"),
+            body: L10n.tr("settings.bark.test.body"),
+            rawURL: rawURL
+        )
+    }
+
+    func post(title: String, body: String, defaults: UserDefaults = .standard) async -> Result<Void, BarkPushError> {
+        let rawURL = defaults.string(forKey: Self.urlDefaultsKey) ?? ""
+        return await post(title: title, body: body, rawURL: rawURL)
+    }
+
+    func post(title: String, body: String, rawURL: String) async -> Result<Void, BarkPushError> {
+        let trimmed = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .failure(.emptyURL) }
+        guard let url = Self.normalizedURL(from: rawURL) else { return .failure(.invalidURL) }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 12
+        request.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
+
+        let payload: [String: String] = [
+            "title": title,
+            "body": body,
+            "group": "TaskTick"
+        ]
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        } catch {
+            return .failure(.network(error.localizedDescription))
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            if let server = try? JSONDecoder().decode(BarkAPIResponse.self, from: data),
+               let code = server.code, code != 200 {
+                return .failure(.serverMessage(server.message ?? "code \(code)"))
+            }
+            if status >= 400 {
+                return .failure(.httpStatus(status))
+            }
+            return .success(())
+        } catch {
+            return .failure(.network(error.localizedDescription))
+        }
+    }
+}
+
+enum BarkPushError: LocalizedError {
+    case emptyURL
+    case invalidURL
+    case httpStatus(Int)
+    case serverMessage(String)
+    case network(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyURL:
+            return L10n.tr("settings.bark.test.failed.empty")
+        case .invalidURL:
+            return L10n.tr("settings.bark.test.failed.invalid")
+        case .httpStatus(let code):
+            return L10n.tr("settings.bark.test.failed.http", code)
+        case .serverMessage(let message):
+            return message
+        case .network(let message):
+            return message
+        }
+    }
+}
+
+private struct BarkAPIResponse: Decodable {
+    let code: Int?
+    let message: String?
+}

--- a/Sources/Engine/ScriptExecutor.swift
+++ b/Sources/Engine/ScriptExecutor.swift
@@ -120,6 +120,8 @@ final class ScriptExecutor: ObservableObject {
         let notifyOnSuccess = task.notifyOnSuccess
         let notifyOnFailure = task.notifyOnFailure
         let notifyOnlyWhenOutput = task.notifyOnlyWhenOutput
+        let barkPushEnabled = task.barkPushEnabled
+        let barkNotifyOnOutputChange = task.barkNotifyOnOutputChange
         let strongReminder = task.strongReminder
         let logId = log.id
 
@@ -244,15 +246,25 @@ final class ScriptExecutor: ObservableObject {
         let globalNotificationsEnabled = UserDefaults.standard.object(forKey: "notificationsEnabled") as? Bool ?? true
         let durationText = "\(L10n.tr("notification.duration")) \(ExecutionLog.formatDuration(durationMs))"
 
-        if globalNotificationsEnabled && notifyOnFailure && result.status != .success {
+        if result.status != .success {
             let exitInfo = "Exit code: \(result.exitCode ?? -1)"
             let stderrLine = result.stderr.components(separatedBy: .newlines).first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? ""
             let body = [exitInfo, durationText, stderrLine].filter { !$0.isEmpty }.joined(separator: " · ")
-            NotificationManager.shared.sendNotification(
-                title: "[\(L10n.tr("notification.failed"))] \(taskName)",
-                body: body
+            let title = "[\(L10n.tr("notification.failed"))] \(taskName)"
+            if globalNotificationsEnabled && notifyOnFailure {
+                NotificationManager.shared.sendNotification(title: title, body: body)
+            }
+            sendBarkIfNeeded(
+                enabled: barkPushEnabled,
+                onlyOnChange: barkNotifyOnOutputChange,
+                title: title,
+                body: body,
+                stdout: result.stdout,
+                stderr: result.stderr,
+                task: fetchedTask,
+                modelContext: modelContext
             )
-        } else if globalNotificationsEnabled && notifyOnSuccess && result.status == .success {
+        } else {
             // "Notify only when output present" mode: polling scripts stay silent on
             // empty runs and only chirp when they `echo` something meaningful.
             // Whitespace-only stdout counts as no output (a script ending in a stray
@@ -268,9 +280,20 @@ final class ScriptExecutor: ObservableObject {
                     return !stripped.isEmpty
                 }) ?? ""
                 let body = [durationText, outputLine].filter { !$0.isEmpty }.joined(separator: " · ")
-                NotificationManager.shared.sendNotification(
-                    title: "[\(L10n.tr("notification.succeeded"))] \(taskName)",
-                    body: body.isEmpty ? L10n.tr("notification.success") : body
+                let title = "[\(L10n.tr("notification.succeeded"))] \(taskName)"
+                let resolvedBody = body.isEmpty ? L10n.tr("notification.success") : body
+                if globalNotificationsEnabled && notifyOnSuccess {
+                    NotificationManager.shared.sendNotification(title: title, body: resolvedBody)
+                }
+                sendBarkIfNeeded(
+                    enabled: barkPushEnabled,
+                    onlyOnChange: barkNotifyOnOutputChange,
+                    title: title,
+                    body: resolvedBody,
+                    stdout: result.stdout,
+                    stderr: result.stderr,
+                    task: fetchedTask,
+                    modelContext: modelContext
                 )
             }
         }
@@ -288,6 +311,35 @@ final class ScriptExecutor: ObservableObject {
         }
 
         return log
+    }
+
+    /// Bark is independent of the macOS notification switch. When
+    /// `onlyOnChange` is on, compare this run's output to the last
+    /// fingerprinted run and stay silent if nothing changed.
+    private func sendBarkIfNeeded(
+        enabled: Bool,
+        onlyOnChange: Bool,
+        title: String,
+        body: String,
+        stdout: String,
+        stderr: String,
+        task: ScheduledTask?,
+        modelContext: ModelContext
+    ) {
+        guard enabled else { return }
+        if onlyOnChange {
+            let fingerprint = BarkPushManager.outputFingerprint(stdout: stdout, stderr: stderr)
+            let shouldSend = BarkPushManager.shouldNotifyOnOutputChange(
+                previousFingerprint: task?.lastBarkOutputFingerprint,
+                currentFingerprint: fingerprint
+            )
+            if let task {
+                task.lastBarkOutputFingerprint = fingerprint
+                do { try modelContext.save() } catch { NSLog("⚠️ Bark fingerprint save failed: \(error)") }
+            }
+            guard shouldSend else { return }
+        }
+        BarkPushManager.shared.send(title: title, body: body)
     }
 
     /// Cancel a running task. Hits both the immediate child (zsh) and the

--- a/Sources/Engine/TaskExporter.swift
+++ b/Sources/Engine/TaskExporter.swift
@@ -49,6 +49,9 @@ struct TaskExporter {
         /// Per-task schedule time zone (issue #41). Optional for older exports;
         /// nil = follow the system time zone.
         let timeZoneIdentifier: String?
+        /// Per-task Bark push opt-in. Optional so older exports still decode.
+        let barkPushEnabled: Bool?
+        let barkNotifyOnOutputChange: Bool?
     }
 
     /// Export all tasks to a JSON file
@@ -182,7 +185,9 @@ struct TaskExporter {
             }(),
             scheduleType: task.scheduleType,
             jitterSeconds: task.jitterSeconds > 0 ? task.jitterSeconds : nil,
-            timeZoneIdentifier: task.timeZoneIdentifier
+            timeZoneIdentifier: task.timeZoneIdentifier,
+            barkPushEnabled: task.barkPushEnabled,
+            barkNotifyOnOutputChange: task.barkNotifyOnOutputChange
         )
     }
 
@@ -230,6 +235,8 @@ struct TaskExporter {
         if let v = item.strongReminder { task.strongReminder = v }
         if let v = item.ignoreExitCode { task.ignoreExitCode = v }
         if let v = item.notifyOnlyWhenOutput { task.notifyOnlyWhenOutput = v }
+        if let v = item.barkPushEnabled { task.barkPushEnabled = v }
+        if let v = item.barkNotifyOnOutputChange { task.barkNotifyOnOutputChange = v }
         if let v = item.isManualOnly { task.isManualOnly = v }
         if let strings = item.additionalTimes, !strings.isEmpty {
             let comps = strings.compactMap { s -> DateComponents? in

--- a/Sources/TaskTickCore/Localization/de.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/de.lproj/Localizable.strings
@@ -113,6 +113,12 @@
 "editor.notify_only_when_output" = "Nur bei Ausgabe benachrichtigen";
 "editor.notify_only_when_output.hint" = "Wenn aktiviert, bleibt ein erfolgreicher Lauf ohne stdout-Ausgabe stumm. Verwende `echo` nur dann, wenn tatsächlich etwas Meldenswertes passiert ist.";
 "editor.notify_hint" = "Benachrichtigungen werden über macOS-Systembenachrichtigungen gesendet, wenn eine Aufgabe abgeschlossen ist.";
+"editor.notify_bark" = "Bark-Push";
+"editor.notify_bark.hint" = "Wenn aktiviert, sendet diese Aufgabe nach Abschluss eine Bark-Benachrichtigung. Die URL wird in den Einstellungen hinterlegt.";
+"editor.notify_bark.on_output_change" = "Nur bei geänderter Ausgabe";
+"editor.notify_bark.on_output_change.hint" = "Vergleicht die Skriptausgabe mit dem letzten Lauf. Gleiche Ausgabe → kein Bark.";
+"editor.notify_bark.missing_url" = "Keine Bark-URL hinterlegt. Öffnen Sie die Einstellungen und fügen Sie die Geräte-URL aus der Bark-App ein.";
+"editor.notify_bark.on" = "Ein";
 "editor.strong_reminder" = "Starke Erinnerung bei Erfolg";
 "editor.strong_reminder_hint" = "Zeigt ein schwebendes Fenster mit der vollständigen Ausgabe an, wenn die Aufgabe erfolgreich ist.";
 "editor.strong_reminder_short" = " Starke Erinnerung";
@@ -344,6 +350,19 @@
 "settings.notifications.on_success" = "Bei Aufgabenerfolg benachrichtigen";
 "settings.notifications.on_failure" = "Bei Aufgabenfehler benachrichtigen";
 "settings.notifications.hint" = "Dies ist ein globaler Schalter. Wenn deaktiviert, werden keine Aufgabenbenachrichtigungen gesendet, auch wenn einzelne Aufgaben Benachrichtigungen aktiviert haben.";
+"settings.bark" = "Bark-Push";
+"settings.bark.url" = "Server-URL";
+"settings.bark.url.placeholder" = "https://api.day.app/your_device_key";
+"settings.bark.test" = "Test senden";
+"settings.bark.test.title" = "TaskTick";
+"settings.bark.test.body" = "Bark-Push funktioniert.";
+"settings.bark.test.success" = "Test gesendet";
+"settings.bark.test.success.message" = "Prüfen Sie auf dem iPhone, ob Bark die Benachrichtigung erhalten hat.";
+"settings.bark.test.failed" = "Test fehlgeschlagen";
+"settings.bark.test.failed.empty" = "Bitte zuerst eine Bark-URL eingeben.";
+"settings.bark.test.failed.invalid" = "Die Bark-URL ist ungültig. Verwenden Sie die Geräte-URL aus der Bark-App.";
+"settings.bark.test.failed.http" = "Bark-Server antwortete mit HTTP %d.";
+"settings.bark.hint" = "Fügen Sie die Geräte-URL aus der Bark-App ein oder nur den Geräteschlüssel. Leer lassen, um Bark global zu deaktivieren. Jede Aufgabe hat einen eigenen Schalter.";
 
 /* Backup */
 "settings.backup" = "Backup";

--- a/Sources/TaskTickCore/Localization/en.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/en.lproj/Localizable.strings
@@ -113,6 +113,12 @@
 "editor.notify_only_when_output" = "Notify Only When Output Exists";
 "editor.notify_only_when_output.hint" = "When enabled, a successful run with no stdout stays silent. Use `echo` only when something worth notifying actually happened.";
 "editor.notify_hint" = "Notifications are sent via macOS system notifications when a task finishes.";
+"editor.notify_bark" = "Bark Push";
+"editor.notify_bark.hint" = "When enabled, this task sends a Bark notification on completion. Set the Bark URL in Settings.";
+"editor.notify_bark.on_output_change" = "Only When Output Changes";
+"editor.notify_bark.on_output_change.hint" = "Compare this run's script output with the last run. Same output → no Bark push.";
+"editor.notify_bark.missing_url" = "Bark URL is not set. Open Settings to add the device URL from the Bark app.";
+"editor.notify_bark.on" = "On";
 "editor.strong_reminder" = "Strong Reminder on Success";
 "editor.strong_reminder_hint" = "Show a floating panel with full output when the task succeeds.";
 "editor.strong_reminder_short" = " Strong Reminder";
@@ -344,6 +350,19 @@
 "settings.notifications.on_success" = "Notify on Task Success";
 "settings.notifications.on_failure" = "Notify on Task Failure";
 "settings.notifications.hint" = "This is a global switch. When disabled, no task notifications will be sent even if individual tasks have notifications enabled.";
+"settings.bark" = "Bark Push";
+"settings.bark.url" = "Server URL";
+"settings.bark.url.placeholder" = "https://api.day.app/your_device_key";
+"settings.bark.test" = "Send Test";
+"settings.bark.test.title" = "TaskTick";
+"settings.bark.test.body" = "Bark push is working.";
+"settings.bark.test.success" = "Test push sent";
+"settings.bark.test.success.message" = "Check your iPhone to confirm Bark received the notification.";
+"settings.bark.test.failed" = "Test push failed";
+"settings.bark.test.failed.empty" = "Enter a Bark URL first.";
+"settings.bark.test.failed.invalid" = "The Bark URL looks invalid. Use the device URL copied from the Bark app.";
+"settings.bark.test.failed.http" = "Bark server returned HTTP %d.";
+"settings.bark.hint" = "Paste the device URL copied from the Bark app, or just the device key. Leave empty to disable Bark globally. Each task has its own Bark toggle.";
 
 /* Backup */
 "settings.backup" = "Backup";

--- a/Sources/TaskTickCore/Localization/es.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/es.lproj/Localizable.strings
@@ -113,6 +113,12 @@
 "editor.notify_only_when_output" = "Notificar solo si hay salida";
 "editor.notify_only_when_output.hint" = "Al activarse, una ejecución exitosa sin stdout no genera notificación. Usa `echo` solo cuando ocurra algo que valga la pena notificar.";
 "editor.notify_hint" = "Las notificaciones se envían a través del sistema de notificaciones de macOS cuando una tarea finaliza.";
+"editor.notify_bark" = "Push de Bark";
+"editor.notify_bark.hint" = "Si está activado, esta tarea envía una notificación Bark al terminar. La URL se configura en Ajustes.";
+"editor.notify_bark.on_output_change" = "Solo si cambia la salida";
+"editor.notify_bark.on_output_change.hint" = "Compara la salida del script con la ejecución anterior. Si es igual, no hay push Bark.";
+"editor.notify_bark.missing_url" = "No hay URL de Bark. Ábrela en Ajustes y pega la URL del dispositivo de la app Bark.";
+"editor.notify_bark.on" = "Activado";
 "editor.strong_reminder" = "Recordatorio destacado al completar";
 "editor.strong_reminder_hint" = "Mostrar un panel flotante con la salida completa cuando la tarea se ejecuta correctamente.";
 "editor.strong_reminder_short" = " Recordatorio destacado";
@@ -344,6 +350,19 @@
 "settings.notifications.on_success" = "Notificar al completar tarea";
 "settings.notifications.on_failure" = "Notificar al fallar tarea";
 "settings.notifications.hint" = "Este es un interruptor global. Cuando está desactivado, no se enviarán notificaciones de ninguna tarea, incluso si las tareas individuales tienen las notificaciones activadas.";
+"settings.bark" = "Push de Bark";
+"settings.bark.url" = "URL del servidor";
+"settings.bark.url.placeholder" = "https://api.day.app/your_device_key";
+"settings.bark.test" = "Enviar prueba";
+"settings.bark.test.title" = "TaskTick";
+"settings.bark.test.body" = "El push de Bark funciona.";
+"settings.bark.test.success" = "Prueba enviada";
+"settings.bark.test.success.message" = "Comprueba en el iPhone que Bark recibió la notificación.";
+"settings.bark.test.failed" = "La prueba falló";
+"settings.bark.test.failed.empty" = "Introduce primero una URL de Bark.";
+"settings.bark.test.failed.invalid" = "La URL de Bark no es válida. Usa la URL del dispositivo copiada de la app Bark.";
+"settings.bark.test.failed.http" = "El servidor Bark devolvió HTTP %d.";
+"settings.bark.hint" = "Pega la URL del dispositivo copiada de la app Bark, o solo la clave. Déjala vacía para desactivar Bark globalmente. Cada tarea tiene su propio interruptor.";
 
 /* Backup */
 "settings.backup" = "Copia de seguridad";

--- a/Sources/TaskTickCore/Localization/fr.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/fr.lproj/Localizable.strings
@@ -105,6 +105,12 @@
 "editor.notify_only_when_output" = "Notifier uniquement en cas de sortie";
 "editor.notify_only_when_output.hint" = "Lorsque cette option est activée, une exécution réussie sans sortie standard reste silencieuse. Utilisez `echo` uniquement lorsqu'un événement mérite réellement une notification.";
 "editor.notify_hint" = "Les notifications sont envoyées via les notifications système de macOS lorsqu'une tâche se termine.";
+"editor.notify_bark" = "Push Bark";
+"editor.notify_bark.hint" = "Si activé, cette tâche envoie une notification Bark à la fin. L'URL se configure dans Réglages.";
+"editor.notify_bark.on_output_change" = "Uniquement si la sortie change";
+"editor.notify_bark.on_output_change.hint" = "Compare la sortie du script avec l'exécution précédente. Identique → pas de push Bark.";
+"editor.notify_bark.missing_url" = "Aucune URL Bark. Ouvrez Réglages et collez l'URL de l'appareil depuis l'app Bark.";
+"editor.notify_bark.on" = "Activé";
 "editor.strong_reminder" = "Rappel fort en cas de succès";
 "editor.strong_reminder_hint" = "Afficher un panneau flottant avec la sortie complète lorsque la tâche réussit.";
 "editor.strong_reminder_short" = " Rappel fort";
@@ -312,6 +318,19 @@
 "settings.notifications.on_success" = "Notifier en cas de succès";
 "settings.notifications.on_failure" = "Notifier en cas d'échec";
 "settings.notifications.hint" = "Ceci est un paramètre global. Lorsqu'il est désactivé, aucune notification ne sera envoyée même si des tâches individuelles ont les notifications activées.";
+"settings.bark" = "Push Bark";
+"settings.bark.url" = "URL du serveur";
+"settings.bark.url.placeholder" = "https://api.day.app/your_device_key";
+"settings.bark.test" = "Envoyer un test";
+"settings.bark.test.title" = "TaskTick";
+"settings.bark.test.body" = "Le push Bark fonctionne.";
+"settings.bark.test.success" = "Test envoyé";
+"settings.bark.test.success.message" = "Vérifiez sur l'iPhone que Bark a bien reçu la notification.";
+"settings.bark.test.failed" = "Échec du test";
+"settings.bark.test.failed.empty" = "Saisissez d'abord une URL Bark.";
+"settings.bark.test.failed.invalid" = "L'URL Bark est invalide. Utilisez l'URL de l'appareil copiée depuis l'app Bark.";
+"settings.bark.test.failed.http" = "Le serveur Bark a renvoyé HTTP %d.";
+"settings.bark.hint" = "Collez l'URL de l'appareil copiée depuis l'app Bark, ou seulement la clé. Laissez vide pour désactiver Bark globalement. Chaque tâche a son propre interrupteur.";
 /* Backup */
 "settings.backup" = "Sauvegarde";
 "settings.backup.section" = "Sauvegarde automatique";

--- a/Sources/TaskTickCore/Localization/id.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/id.lproj/Localizable.strings
@@ -113,6 +113,12 @@
 "editor.notify_only_when_output" = "Beri Tahu Hanya Jika Ada Output";
 "editor.notify_only_when_output.hint" = "Jika diaktifkan, eksekusi yang berhasil tanpa stdout akan tetap senyap. Gunakan `echo` hanya saat ada sesuatu yang benar-benar layak diberitahukan.";
 "editor.notify_hint" = "Notifikasi dikirim melalui notifikasi sistem macOS saat tugas selesai.";
+"editor.notify_bark" = "Push Bark";
+"editor.notify_bark.hint" = "Jika diaktifkan, tugas ini mengirim notifikasi Bark saat selesai. URL diatur di Pengaturan.";
+"editor.notify_bark.on_output_change" = "Hanya jika keluaran berubah";
+"editor.notify_bark.on_output_change.hint" = "Membandingkan keluaran skrip dengan eksekusi sebelumnya. Sama → tidak ada push Bark.";
+"editor.notify_bark.missing_url" = "URL Bark belum diisi. Buka Pengaturan dan tempel URL perangkat dari aplikasi Bark.";
+"editor.notify_bark.on" = "Aktif";
 "editor.strong_reminder" = "Pengingat Kuat saat Berhasil";
 "editor.strong_reminder_hint" = "Tampilkan panel mengambang dengan output lengkap saat tugas berhasil.";
 "editor.strong_reminder_short" = " Pengingat Kuat";
@@ -344,6 +350,19 @@
 "settings.notifications.on_success" = "Notifikasi saat Tugas Berhasil";
 "settings.notifications.on_failure" = "Notifikasi saat Tugas Gagal";
 "settings.notifications.hint" = "Ini adalah pengaturan global. Jika dinonaktifkan, tidak ada notifikasi tugas yang akan dikirim meskipun tugas individual memiliki notifikasi yang diaktifkan.";
+"settings.bark" = "Push Bark";
+"settings.bark.url" = "URL server";
+"settings.bark.url.placeholder" = "https://api.day.app/your_device_key";
+"settings.bark.test" = "Kirim uji coba";
+"settings.bark.test.title" = "TaskTick";
+"settings.bark.test.body" = "Push Bark berfungsi.";
+"settings.bark.test.success" = "Uji coba terkirim";
+"settings.bark.test.success.message" = "Periksa iPhone untuk memastikan Bark menerima notifikasi.";
+"settings.bark.test.failed" = "Uji coba gagal";
+"settings.bark.test.failed.empty" = "Masukkan URL Bark terlebih dahulu.";
+"settings.bark.test.failed.invalid" = "URL Bark tidak valid. Gunakan URL perangkat yang disalin dari aplikasi Bark.";
+"settings.bark.test.failed.http" = "Server Bark mengembalikan HTTP %d.";
+"settings.bark.hint" = "Tempel URL perangkat dari aplikasi Bark, atau hanya kunci perangkat. Kosongkan untuk menonaktifkan Bark secara global. Setiap tugas punya sakelar sendiri.";
 
 /* Backup */
 "settings.backup" = "Cadangan";

--- a/Sources/TaskTickCore/Localization/it.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/it.lproj/Localizable.strings
@@ -113,6 +113,12 @@
 "editor.notify_only_when_output" = "Notifica solo in presenza di output";
 "editor.notify_only_when_output.hint" = "Se abilitato, un'esecuzione riuscita senza stdout resta silenziosa. Usa `echo` solo quando accade davvero qualcosa che vale la pena notificare.";
 "editor.notify_hint" = "Le notifiche vengono inviate tramite il sistema di notifiche di macOS al termine di un'attività.";
+"editor.notify_bark" = "Push Bark";
+"editor.notify_bark.hint" = "Se attivato, questa attività invia una notifica Bark al termine. L'URL si imposta in Impostazioni.";
+"editor.notify_bark.on_output_change" = "Solo se l'output cambia";
+"editor.notify_bark.on_output_change.hint" = "Confronta l'output dello script con l'esecuzione precedente. Uguale → nessun push Bark.";
+"editor.notify_bark.missing_url" = "URL Bark non impostato. Apri Impostazioni e incolla l'URL del dispositivo dall'app Bark.";
+"editor.notify_bark.on" = "Attivo";
 "editor.strong_reminder" = "Promemoria forte in caso di successo";
 "editor.strong_reminder_hint" = "Mostra un pannello mobile con l'output completo quando l'attività ha successo.";
 "editor.strong_reminder_short" = " Promemoria forte";
@@ -344,6 +350,19 @@
 "settings.notifications.on_success" = "Notifica in caso di successo";
 "settings.notifications.on_failure" = "Notifica in caso di errore";
 "settings.notifications.hint" = "Questo è un interruttore globale. Se disattivato, nessuna notifica verrà inviata anche se le singole attività hanno le notifiche abilitate.";
+"settings.bark" = "Push Bark";
+"settings.bark.url" = "URL del server";
+"settings.bark.url.placeholder" = "https://api.day.app/your_device_key";
+"settings.bark.test" = "Invia test";
+"settings.bark.test.title" = "TaskTick";
+"settings.bark.test.body" = "Il push Bark funziona.";
+"settings.bark.test.success" = "Test inviato";
+"settings.bark.test.success.message" = "Controlla sull'iPhone che Bark abbia ricevuto la notifica.";
+"settings.bark.test.failed" = "Test non riuscito";
+"settings.bark.test.failed.empty" = "Inserisci prima un URL Bark.";
+"settings.bark.test.failed.invalid" = "L'URL Bark non è valido. Usa l'URL del dispositivo copiato dall'app Bark.";
+"settings.bark.test.failed.http" = "Il server Bark ha restituito HTTP %d.";
+"settings.bark.hint" = "Incolla l'URL del dispositivo copiato dall'app Bark, oppure solo la chiave. Lascia vuoto per disattivare Bark a livello globale. Ogni attività ha un interruttore proprio.";
 
 /* Backup */
 "settings.backup" = "Backup";

--- a/Sources/TaskTickCore/Localization/ja.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/ja.lproj/Localizable.strings
@@ -113,6 +113,12 @@
 "editor.notify_only_when_output" = "出力がある場合のみ通知";
 "editor.notify_only_when_output.hint" = "有効にすると、実行が成功しても stdout に出力がない場合は通知されません。`echo` で実際に通知する価値のある内容が出力されたときのみ通知されます。";
 "editor.notify_hint" = "タスク完了時にmacOSのシステム通知で通知されます。";
+"editor.notify_bark" = "Bark プッシュ";
+"editor.notify_bark.hint" = "有効にすると、このタスクの完了時に Bark 通知を送ります。URL は設定で入力します。";
+"editor.notify_bark.on_output_change" = "出力が変わったときだけ通知";
+"editor.notify_bark.on_output_change.hint" = "今回と前回のスクリプト出力を比較します。同じなら Bark は送りません。";
+"editor.notify_bark.missing_url" = "Bark URL が未設定です。設定で Bark アプリのデバイス URL を入力してください。";
+"editor.notify_bark.on" = "オン";
 "editor.strong_reminder" = "成功時に強調リマインダー";
 "editor.strong_reminder_hint" = "タスク成功時に出力全文を表示するフローティングパネルを表示します。";
 "editor.strong_reminder_short" = " 強調リマインダー";
@@ -344,6 +350,19 @@
 "settings.notifications.on_success" = "タスク成功時に通知";
 "settings.notifications.on_failure" = "タスク失敗時に通知";
 "settings.notifications.hint" = "これはグローバルスイッチです。無効にすると、個別タスクで通知が有効でも通知は送信されません。";
+"settings.bark" = "Bark プッシュ";
+"settings.bark.url" = "サーバー URL";
+"settings.bark.url.placeholder" = "https://api.day.app/your_device_key";
+"settings.bark.test" = "テスト送信";
+"settings.bark.test.title" = "TaskTick";
+"settings.bark.test.body" = "Bark プッシュは動作しています。";
+"settings.bark.test.success" = "テストを送信しました";
+"settings.bark.test.success.message" = "iPhone で Bark 通知を確認してください。";
+"settings.bark.test.failed" = "テスト送信に失敗しました";
+"settings.bark.test.failed.empty" = "先に Bark URL を入力してください。";
+"settings.bark.test.failed.invalid" = "Bark URL が無効です。Bark アプリからコピーしたデバイス URL を使ってください。";
+"settings.bark.test.failed.http" = "Bark サーバーが HTTP %d を返しました。";
+"settings.bark.hint" = "Bark アプリからコピーしたデバイス URL、またはデバイスキーを貼り付けます。空欄にすると全体で Bark が無効になります。各タスクで個別に切り替えられます。";
 
 /* Backup */
 "settings.backup" = "バックアップ";

--- a/Sources/TaskTickCore/Localization/ko.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/ko.lproj/Localizable.strings
@@ -113,6 +113,12 @@
 "editor.notify_only_when_output" = "출력이 있을 때만 알림";
 "editor.notify_only_when_output.hint" = "활성화하면 실행에 성공했지만 stdout 출력이 없는 경우 알림을 보내지 않습니다. 스크립트가 `echo`로 알릴 만한 정보를 실제로 출력했을 때만 알림이 전송됩니다.";
 "editor.notify_hint" = "작업 완료 시 macOS 시스템 알림으로 전송됩니다.";
+"editor.notify_bark" = "Bark 푸시";
+"editor.notify_bark.hint" = "켜면 이 작업이 완료될 때 Bark 알림을 보냅니다. 주소는 설정에서 입력합니다.";
+"editor.notify_bark.on_output_change" = "출력이 바뀔 때만 알림";
+"editor.notify_bark.on_output_change.hint" = "이번 실행과 이전 실행의 스크립트 출력을 비교합니다. 같으면 Bark를 보내지 않습니다.";
+"editor.notify_bark.missing_url" = "Bark URL이 없습니다. 설정에서 Bark 앱의 기기 URL을 입력하세요.";
+"editor.notify_bark.on" = "켜짐";
 "editor.strong_reminder" = "성공 시 강조 알림";
 "editor.strong_reminder_hint" = "작업 성공 시 전체 출력이 포함된 플로팅 패널을 표시합니다.";
 "editor.strong_reminder_short" = " 강조 알림";
@@ -344,6 +350,19 @@
 "settings.notifications.on_success" = "작업 성공 시 알림";
 "settings.notifications.on_failure" = "작업 실패 시 알림";
 "settings.notifications.hint" = "전역 스위치입니다. 비활성화하면 개별 작업에서 알림이 활성화되어 있어도 알림이 전송되지 않습니다.";
+"settings.bark" = "Bark 푸시";
+"settings.bark.url" = "서버 URL";
+"settings.bark.url.placeholder" = "https://api.day.app/your_device_key";
+"settings.bark.test" = "테스트 보내기";
+"settings.bark.test.title" = "TaskTick";
+"settings.bark.test.body" = "Bark 푸시가 작동합니다.";
+"settings.bark.test.success" = "테스트 푸시를 보냈습니다";
+"settings.bark.test.success.message" = "iPhone에서 Bark 알림을 확인하세요.";
+"settings.bark.test.failed" = "테스트 푸시 실패";
+"settings.bark.test.failed.empty" = "먼저 Bark URL을 입력하세요.";
+"settings.bark.test.failed.invalid" = "Bark URL이 올바르지 않습니다. Bark 앱에서 복사한 기기 URL을 사용하세요.";
+"settings.bark.test.failed.http" = "Bark 서버가 HTTP %d를 반환했습니다.";
+"settings.bark.hint" = "Bark 앱에서 복사한 기기 URL 또는 기기 키를 붙여넣으세요. 비워 두면 전역으로 Bark가 꺼집니다. 각 작업에서 따로 켤 수 있습니다.";
 
 /* Backup */
 "settings.backup" = "백업";

--- a/Sources/TaskTickCore/Localization/ru.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/ru.lproj/Localizable.strings
@@ -113,6 +113,12 @@
 "editor.notify_only_when_output" = "Уведомлять только при наличии вывода";
 "editor.notify_only_when_output.hint" = "Если включено, успешный запуск без вывода в stdout остаётся беззвучным. Используйте `echo` только тогда, когда действительно произошло что-то, о чём стоит уведомить.";
 "editor.notify_hint" = "Уведомления отправляются через системные уведомления macOS по завершении задачи.";
+"editor.notify_bark" = "Push Bark";
+"editor.notify_bark.hint" = "Если включено, эта задача отправит уведомление Bark по завершении. URL задаётся в настройках.";
+"editor.notify_bark.on_output_change" = "Только при изменении вывода";
+"editor.notify_bark.on_output_change.hint" = "Сравнивает вывод скрипта с прошлым запуском. Одинаковый вывод — без push Bark.";
+"editor.notify_bark.missing_url" = "URL Bark не задан. Откройте настройки и вставьте URL устройства из приложения Bark.";
+"editor.notify_bark.on" = "Вкл.";
 "editor.strong_reminder" = "Усиленное напоминание при успехе";
 "editor.strong_reminder_hint" = "Показать плавающую панель с полным выводом при успешном выполнении задачи.";
 "editor.strong_reminder_short" = " Усиленное напоминание";
@@ -344,6 +350,19 @@
 "settings.notifications.on_success" = "Уведомлять при успехе";
 "settings.notifications.on_failure" = "Уведомлять при ошибке";
 "settings.notifications.hint" = "Это глобальный переключатель. При отключении уведомления не будут отправляться, даже если они включены для отдельных задач.";
+"settings.bark" = "Push Bark";
+"settings.bark.url" = "URL сервера";
+"settings.bark.url.placeholder" = "https://api.day.app/your_device_key";
+"settings.bark.test" = "Отправить тест";
+"settings.bark.test.title" = "TaskTick";
+"settings.bark.test.body" = "Push Bark работает.";
+"settings.bark.test.success" = "Тест отправлен";
+"settings.bark.test.success.message" = "Проверьте на iPhone, что Bark получил уведомление.";
+"settings.bark.test.failed" = "Тест не удался";
+"settings.bark.test.failed.empty" = "Сначала введите URL Bark.";
+"settings.bark.test.failed.invalid" = "URL Bark некорректен. Используйте URL устройства, скопированный из приложения Bark.";
+"settings.bark.test.failed.http" = "Сервер Bark вернул HTTP %d.";
+"settings.bark.hint" = "Вставьте URL устройства из приложения Bark или только ключ. Оставьте пустым, чтобы отключить Bark глобально. У каждой задачи свой переключатель.";
 
 /* Backup */
 "settings.backup" = "Резервное копирование";

--- a/Sources/TaskTickCore/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/zh-Hans.lproj/Localizable.strings
@@ -113,6 +113,12 @@
 "editor.notify_only_when_output" = "仅在有输出时通知";
 "editor.notify_only_when_output.hint" = "开启后，执行成功但脚本没有任何 stdout 输出（例如轮询空跑）将不弹通知；只在脚本通过 `echo` 主动打印业务信息时才通知。";
 "editor.notify_hint" = "任务完成时通过 macOS 系统通知推送。";
+"editor.notify_bark" = "Bark 推送";
+"editor.notify_bark.hint" = "开启后，该任务完成时会发送 Bark 推送。推送地址在 App 设置中填写。";
+"editor.notify_bark.on_output_change" = "仅在输出有变动时通知";
+"editor.notify_bark.on_output_change.hint" = "对比本次与上次的脚本输出。输出相同则不推送 Bark。";
+"editor.notify_bark.missing_url" = "尚未填写 Bark 推送地址，请先到设置中填入 Bark App 里复制的设备地址。";
+"editor.notify_bark.on" = "已开启";
 "editor.strong_reminder" = "成功时强提醒";
 "editor.strong_reminder_hint" = "任务成功后弹出浮动面板，显示完整输出内容。";
 "editor.strong_reminder_short" = "强提醒";
@@ -344,6 +350,19 @@
 "settings.notifications.on_success" = "任务成功时通知";
 "settings.notifications.on_failure" = "任务失败时通知";
 "settings.notifications.hint" = "这是全局开关。关闭后，即使任务单独开启了通知，也不会发送提醒。";
+"settings.bark" = "Bark 推送";
+"settings.bark.url" = "推送地址";
+"settings.bark.url.placeholder" = "https://api.day.app/你的设备 Key";
+"settings.bark.test" = "发送测试";
+"settings.bark.test.title" = "TaskTick";
+"settings.bark.test.body" = "Bark 推送已接通。";
+"settings.bark.test.success" = "测试推送已发送";
+"settings.bark.test.success.message" = "请在 iPhone 上确认是否收到 Bark 通知。";
+"settings.bark.test.failed" = "测试推送失败";
+"settings.bark.test.failed.empty" = "请先填写 Bark 推送地址。";
+"settings.bark.test.failed.invalid" = "Bark 地址格式不正确。请粘贴 Bark App 里复制的设备推送地址。";
+"settings.bark.test.failed.http" = "Bark 服务器返回 HTTP %d。";
+"settings.bark.hint" = "粘贴 Bark App 中复制的设备推送地址，也可以只填设备 Key。留空则全局关闭 Bark。每个任务可单独开关。";
 
 /* 备份 */
 "settings.backup" = "备份";

--- a/Sources/TaskTickCore/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/zh-Hant.lproj/Localizable.strings
@@ -113,6 +113,12 @@
 "editor.notify_only_when_output" = "僅在有輸出時通知";
 "editor.notify_only_when_output.hint" = "啟用後，執行成功但指令稿沒有任何 stdout 輸出（例如輪詢空跑）將不彈出通知；只在指令稿透過 `echo` 主動印出業務資訊時才會通知。";
 "editor.notify_hint" = "任務完成時透過 macOS 系統通知推播。";
+"editor.notify_bark" = "Bark 推送";
+"editor.notify_bark.hint" = "開啟後，此任務完成時會傳送 Bark 推送。推送地址在 App 設定中填寫。";
+"editor.notify_bark.on_output_change" = "僅在輸出有變動時通知";
+"editor.notify_bark.on_output_change.hint" = "比對本次與上次的腳本輸出。輸出相同則不推送 Bark。";
+"editor.notify_bark.missing_url" = "尚未填寫 Bark 推送地址，請先到設定中貼上 Bark App 複製的裝置地址。";
+"editor.notify_bark.on" = "已開啟";
 "editor.strong_reminder" = "成功時強提醒";
 "editor.strong_reminder_hint" = "任務成功後彈出浮動面板，顯示完整輸出內容。";
 "editor.strong_reminder_short" = "強提醒";
@@ -344,6 +350,19 @@
 "settings.notifications.on_success" = "任務成功時通知";
 "settings.notifications.on_failure" = "任務失敗時通知";
 "settings.notifications.hint" = "這是全域開關。關閉後，即使任務單獨開啟了通知，也不會傳送提醒。";
+"settings.bark" = "Bark 推送";
+"settings.bark.url" = "推送地址";
+"settings.bark.url.placeholder" = "https://api.day.app/你的裝置 Key";
+"settings.bark.test" = "傳送測試";
+"settings.bark.test.title" = "TaskTick";
+"settings.bark.test.body" = "Bark 推送已接通。";
+"settings.bark.test.success" = "測試推送已傳送";
+"settings.bark.test.success.message" = "請在 iPhone 上確認是否收到 Bark 通知。";
+"settings.bark.test.failed" = "測試推送失敗";
+"settings.bark.test.failed.empty" = "請先填寫 Bark 推送地址。";
+"settings.bark.test.failed.invalid" = "Bark 地址格式不正確。請貼上 Bark App 複製的裝置推送地址。";
+"settings.bark.test.failed.http" = "Bark 伺服器回傳 HTTP %d。";
+"settings.bark.hint" = "貼上 Bark App 複製的裝置推送地址，也可以只填裝置 Key。留空則全域關閉 Bark。每個任務可單獨開關。";
 
 /* Backup */
 "settings.backup" = "備份";

--- a/Sources/TaskTickCore/Models/ScheduledTask.swift
+++ b/Sources/TaskTickCore/Models/ScheduledTask.swift
@@ -219,6 +219,17 @@ public final class ScheduledTask {
     /// "action feedback" banner (Started/Stopped/Restarted). Default `false`
     /// keeps these banners off unless the user opts in per task.
     public var notifyOnAction: Bool = false
+    /// When true, this task sends a Bark push on completion (success and
+    /// failure). The device URL is app-wide (`barkServerURL`); default `false`
+    /// keeps existing tasks unchanged on SwiftData migration.
+    public var barkPushEnabled: Bool = false
+    /// When true (and Bark is on), a completion push is sent only if this
+    /// run's script output differs from the previous run. Default `false`
+    /// keeps existing tasks notifying on every completion.
+    public var barkNotifyOnOutputChange: Bool = false
+    /// SHA-256 of the last compared script output. Runtime only — not
+    /// exported. nil means no previous run has been fingerprinted yet.
+    public var lastBarkOutputFingerprint: String? = nil
     /// Upper bound (seconds) for random scheduling jitter — issue #38. When > 0
     /// every computed fire time gets a deterministic pseudo-random 0...N second
     /// delay so repeats don't hit machine-precise instants. Default 0 keeps

--- a/Sources/Views/Editor/TaskEditorView.swift
+++ b/Sources/Views/Editor/TaskEditorView.swift
@@ -85,6 +85,9 @@ struct TaskEditorView: View {
     @State private var notifyOnFailure = true
     @State private var notifyOnAction = false
     @State private var notifyOnlyWhenOutput = false
+    @State private var barkPushEnabled = false
+    @State private var barkNotifyOnOutputChange = false
+    @AppStorage("barkServerURL") private var barkServerURL = ""
     @State private var strongReminder = false
     @State private var ignoreExitCode = false
 
@@ -866,6 +869,34 @@ struct TaskEditorView: View {
             }
 
             Section {
+                Toggle(isOn: $barkPushEnabled) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(L10n.tr("editor.notify_bark"))
+                        Text(isBarkURLConfigured
+                             ? L10n.tr("editor.notify_bark.hint")
+                             : L10n.tr("editor.notify_bark.missing_url"))
+                            .font(.caption)
+                            .foregroundStyle(isBarkURLConfigured ? Color.secondary : Color.orange)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                Toggle(isOn: $barkNotifyOnOutputChange) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(L10n.tr("editor.notify_bark.on_output_change"))
+                        if barkPushEnabled && barkNotifyOnOutputChange {
+                            Text(L10n.tr("editor.notify_bark.on_output_change.hint"))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+                .disabled(!barkPushEnabled)
+            } header: {
+                Text(L10n.tr("settings.bark"))
+            }
+
+            Section {
                 Toggle(L10n.tr("editor.strong_reminder"), isOn: $strongReminder)
             } footer: {
                 Text(L10n.tr("editor.strong_reminder_hint"))
@@ -887,6 +918,10 @@ struct TaskEditorView: View {
                 }
             }
         }
+    }
+
+    private var isBarkURLConfigured: Bool {
+        BarkPushManager.normalizedURL(from: barkServerURL) != nil
     }
 
     // MARK: - Script Validation
@@ -1122,6 +1157,8 @@ struct TaskEditorView: View {
         notifyOnFailure = true
         notifyOnAction = false
         notifyOnlyWhenOutput = false
+        barkPushEnabled = false
+        barkNotifyOnOutputChange = false
         strongReminder = false
         ignoreExitCode = false
         selectedTab = 0
@@ -1151,6 +1188,8 @@ struct TaskEditorView: View {
         notifyOnFailure = task.notifyOnFailure
         notifyOnAction = task.notifyOnAction
         notifyOnlyWhenOutput = task.notifyOnlyWhenOutput
+        barkPushEnabled = task.barkPushEnabled
+        barkNotifyOnOutputChange = task.barkNotifyOnOutputChange
         strongReminder = task.strongReminder
         ignoreExitCode = task.ignoreExitCode
         repeatType = task.repeatType
@@ -1213,6 +1252,8 @@ struct TaskEditorView: View {
         target.notifyOnFailure = notifyOnFailure
         target.notifyOnAction = notifyOnAction
         target.notifyOnlyWhenOutput = notifyOnlyWhenOutput
+        target.barkPushEnabled = barkPushEnabled
+        target.barkNotifyOnOutputChange = barkNotifyOnOutputChange
         target.strongReminder = strongReminder
         target.ignoreExitCode = ignoreExitCode
         target.isEnabled = isEnabled

--- a/Sources/Views/Main/TaskDetailView.swift
+++ b/Sources/Views/Main/TaskDetailView.swift
@@ -317,6 +317,14 @@ struct TaskDetailView: View {
                         }
                     }()
                     detailRow(L10n.tr("editor.section.notification"), value: notifyLabel)
+                    if task.barkPushEnabled {
+                        detailRow(
+                            L10n.tr("settings.bark"),
+                            value: task.barkNotifyOnOutputChange
+                                ? L10n.tr("editor.notify_bark.on_output_change")
+                                : L10n.tr("editor.notify_bark.on")
+                        )
+                    }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/Views/Main/TaskListView.swift
+++ b/Sources/Views/Main/TaskListView.swift
@@ -280,6 +280,8 @@ struct TaskListView: View {
         copy.runOnLaunch = task.runOnLaunch
         copy.notifyOnAction = task.notifyOnAction
         copy.notifyOnlyWhenOutput = task.notifyOnlyWhenOutput
+        copy.barkPushEnabled = task.barkPushEnabled
+        copy.barkNotifyOnOutputChange = task.barkNotifyOnOutputChange
         copy.strongReminder = task.strongReminder
         copy.ignoreExitCode = task.ignoreExitCode
         copy.isManualOnly = task.isManualOnly

--- a/Sources/Views/Settings/SettingsView.swift
+++ b/Sources/Views/Settings/SettingsView.swift
@@ -14,6 +14,11 @@ struct SettingsView: View {
 
     // Notifications
     @AppStorage("notificationsEnabled") private var notificationsEnabled = true
+    @AppStorage("barkServerURL") private var barkServerURL = ""
+    @State private var isSendingBarkTest = false
+    @State private var showBarkTestResult = false
+    @State private var barkTestSucceeded = false
+    @State private var barkTestErrorMessage: String?
 
     // Logs
     @AppStorage("logRetentionDays") private var logRetentionDays = 30
@@ -112,6 +117,29 @@ struct SettingsView: View {
                 Text(L10n.tr("settings.notifications.hint"))
             }
 
+            Section {
+                TextField(L10n.tr("settings.bark.url.placeholder"), text: $barkServerURL)
+                    .textFieldStyle(.roundedBorder)
+
+                HStack(spacing: 8) {
+                    Button(L10n.tr("settings.bark.test")) {
+                        sendBarkTest()
+                    }
+                    .disabled(barkServerURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                              || isSendingBarkTest)
+                    .pointerCursor()
+
+                    if isSendingBarkTest {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                }
+            } header: {
+                Text(L10n.tr("settings.bark"))
+            } footer: {
+                Text(L10n.tr("settings.bark.hint"))
+            }
+
             Section(L10n.tr("settings.general.defaults")) {
                 Picker(L10n.tr("settings.general.default_shell"), selection: $defaultShell) {
                     ForEach(AvailableShells.load(including: defaultShell), id: \.self) { shell in
@@ -132,6 +160,16 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
+        .alert(barkTestSucceeded
+               ? L10n.tr("settings.bark.test.success")
+               : L10n.tr("settings.bark.test.failed"),
+               isPresented: $showBarkTestResult) {
+            Button("OK") {}
+        } message: {
+            Text(barkTestSucceeded
+                 ? L10n.tr("settings.bark.test.success.message")
+                 : (barkTestErrorMessage ?? L10n.tr("settings.bark.test.failed.invalid")))
+        }
     }
 
     // MARK: - Quick Launcher
@@ -653,6 +691,23 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
+    }
+
+    private func sendBarkTest() {
+        isSendingBarkTest = true
+        Task {
+            let result = await BarkPushManager.shared.sendTest()
+            isSendingBarkTest = false
+            switch result {
+            case .success:
+                barkTestSucceeded = true
+                barkTestErrorMessage = nil
+            case .failure(let error):
+                barkTestSucceeded = false
+                barkTestErrorMessage = error.localizedDescription
+            }
+            showBarkTestResult = true
+        }
     }
 
     private func applyAppearance(_ mode: String) {

--- a/Tests/AppTests/BarkPushManagerTests.swift
+++ b/Tests/AppTests/BarkPushManagerTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import TaskTickApp
+
+final class BarkPushManagerTests: XCTestCase {
+
+    func testEmptyAndWhitespaceRejected() {
+        XCTAssertNil(BarkPushManager.normalizedURL(from: ""))
+        XCTAssertNil(BarkPushManager.normalizedURL(from: "   "))
+        XCTAssertNil(BarkPushManager.normalizedURL(from: "\n\t"))
+    }
+
+    func testOfficialDeviceURLAccepted() {
+        let url = BarkPushManager.normalizedURL(from: "https://api.day.app/abcdefghijklmnop/")
+        XCTAssertEqual(url?.absoluteString, "https://api.day.app/abcdefghijklmnop")
+    }
+
+    func testTrailingSlashAndWhitespaceStripped() {
+        let url = BarkPushManager.normalizedURL(from: "  https://api.day.app/deviceKey  ")
+        XCTAssertEqual(url?.absoluteString, "https://api.day.app/deviceKey")
+    }
+
+    func testQueryItemsPreserved() {
+        let url = BarkPushManager.normalizedURL(from: "https://api.day.app/deviceKey/?sound=bell")
+        XCTAssertEqual(url?.scheme, "https")
+        XCTAssertEqual(url?.host, "api.day.app")
+        XCTAssertEqual(url?.path, "/deviceKey")
+        XCTAssertEqual(url?.query, "sound=bell")
+    }
+
+    func testBareDeviceKeyBecomesOfficialURL() {
+        let url = BarkPushManager.normalizedURL(from: "AbC_12-xy")
+        XCTAssertEqual(url?.absoluteString, "https://api.day.app/AbC_12-xy")
+    }
+
+    func testSelfHostedURLAccepted() {
+        let url = BarkPushManager.normalizedURL(from: "https://bark.example.com/mykey/")
+        XCTAssertEqual(url?.absoluteString, "https://bark.example.com/mykey")
+    }
+
+    func testHostOnlyOfficialURLRejected() {
+        XCTAssertNil(BarkPushManager.normalizedURL(from: "https://api.day.app"))
+        XCTAssertNil(BarkPushManager.normalizedURL(from: "https://api.day.app/"))
+    }
+
+    func testUnsupportedSchemeRejected() {
+        XCTAssertNil(BarkPushManager.normalizedURL(from: "ftp://api.day.app/key"))
+        XCTAssertNil(BarkPushManager.normalizedURL(from: "not a url"))
+        XCTAssertNil(BarkPushManager.normalizedURL(from: "key with spaces"))
+    }
+
+    func testIsConfiguredReadsDefaults() {
+        let suite = "test.bark.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertFalse(BarkPushManager.isConfigured(defaults))
+
+        defaults.set("https://api.day.app/deviceKey", forKey: BarkPushManager.urlDefaultsKey)
+        XCTAssertTrue(BarkPushManager.isConfigured(defaults))
+
+        defaults.set("   ", forKey: BarkPushManager.urlDefaultsKey)
+        XCTAssertFalse(BarkPushManager.isConfigured(defaults))
+    }
+
+    func testEmptyURLPostFailsWithoutNetwork() async {
+        let suite = "test.bark.empty.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let result = await BarkPushManager.shared.post(title: "t", body: "b", defaults: defaults)
+        guard case .failure(let error) = result else {
+            return XCTFail("expected failure for empty URL")
+        }
+        if case .emptyURL = error { return }
+        XCTFail("expected emptyURL, got \(error)")
+    }
+
+    func testOutputFingerprintIgnoresSurroundingWhitespace() {
+        let a = BarkPushManager.outputFingerprint(stdout: "hello\n", stderr: "")
+        let b = BarkPushManager.outputFingerprint(stdout: "  hello  ", stderr: "ignored")
+        XCTAssertEqual(a, b)
+    }
+
+    func testOutputFingerprintChangesWhenStdoutChanges() {
+        let a = BarkPushManager.outputFingerprint(stdout: "ok", stderr: "")
+        let b = BarkPushManager.outputFingerprint(stdout: "changed", stderr: "")
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testOutputFingerprintFallsBackToStderrWhenStdoutEmpty() {
+        let fromErr = BarkPushManager.outputFingerprint(stdout: "  \n", stderr: "boom")
+        let sameErr = BarkPushManager.outputFingerprint(stdout: "", stderr: "boom")
+        let fromOut = BarkPushManager.outputFingerprint(stdout: "boom", stderr: "")
+        XCTAssertEqual(fromErr, sameErr)
+        XCTAssertEqual(fromErr, fromOut)
+    }
+
+    func testShouldNotifyOnFirstRunAndOnChangeOnly() {
+        let fp1 = BarkPushManager.outputFingerprint(stdout: "v1", stderr: "")
+        let fp2 = BarkPushManager.outputFingerprint(stdout: "v2", stderr: "")
+        XCTAssertTrue(BarkPushManager.shouldNotifyOnOutputChange(previousFingerprint: nil, currentFingerprint: fp1))
+        XCTAssertFalse(BarkPushManager.shouldNotifyOnOutputChange(previousFingerprint: fp1, currentFingerprint: fp1))
+        XCTAssertTrue(BarkPushManager.shouldNotifyOnOutputChange(previousFingerprint: fp1, currentFingerprint: fp2))
+    }
+
+    func testInvalidURLPostFailsWithoutNetwork() async {
+        let suite = "test.bark.invalid.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set("https://api.day.app", forKey: BarkPushManager.urlDefaultsKey)
+        let result = await BarkPushManager.shared.post(title: "t", body: "b", defaults: defaults)
+        guard case .failure(let error) = result else {
+            return XCTFail("expected failure for invalid URL")
+        }
+        if case .invalidURL = error { return }
+        XCTFail("expected invalidURL, got \(error)")
+    }
+}


### PR DESCRIPTION
## 改动目的

TaskTick 目前只能走 macOS 系统通知。很多人任务跑在电脑上，人却不在电脑前，希望把执行结果推到手机。Bark 是常见的 iOS 推送通道，这次在原有架构上加一条并列的 Bark 通道，不改调度、执行和系统通知的行为。

## 改动范围

### 1. App 设置：填写 Bark 地址

- 设置 → 通用，新增 **Bark 推送** 区块
- 粘贴 Bark App 里复制的设备地址（`https://api.day.app/<key>`），也可以只填设备 Key
- 支持自建 Bark 服务器地址
- 留空 = 全局关闭 Bark
- 提供「发送测试」，方便确认手机能否收到

### 2. 单个任务：开关 Bark

- 任务编辑 → 通知页，每个任务可单独打开 / 关闭 Bark
- 默认关闭，已有任务不会突然开始推
- 复制、导出、备份会带上这个开关
- 详情页会显示 Bark 是否开启

### 3. 单个任务：仅在输出有变动时通知

- 打开 Bark 后，可再开 **仅在输出有变动时通知**
- 对比本次与上次脚本输出（优先 stdout，为空则比 stderr）
- 输出相同不推；第一次运行或输出变化才推
- 前后空白不计入差异
- 成功、失败都按这个规则过滤

### 4. 和系统通知的关系

- Bark 与 macOS 系统通知互相独立
- 关掉「启用通知」只影响电脑横幅，不影响 Bark
- 「仅在有输出时通知」对 Bark 的成功推送仍然生效，避免轮询空跑刷屏

## 实现要点

- 新增 `BarkPushManager`，POST JSON 到 Bark，和现有 `NotificationManager` 并列
- `ScheduledTask` 增加 `barkPushEnabled`、`barkNotifyOnOutputChange`（SwiftData 默认值，老数据自动迁移）
- 任务完成后由 `ScriptExecutor` 决定是否推送
- 11 种语言补齐文案
- 单测覆盖 URL 解析、输出指纹、是否应推送

## 使用方式

1. 设置里填入 Bark 地址，可先发一条测试
2. 需要推送的任务打开「Bark 推送」
3. 监控类任务可再打开「仅在输出有变动时通知」