### PR TITLE
feat: automatically enforce execution log retention

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -120,6 +120,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ScriptExecutor.shared.cancelAll(graceful: 0.2)
         TaskScheduler.shared.stop()
         TaskScheduler.shared.stopAdoptionPoll()
+        ExecutionLogRetentionManager.shared.stop()
         do {
             try TaskTickApp._sharedModelContainer.mainContext.save()
         } catch {

--- a/Sources/App/TaskTickApp.swift
+++ b/Sources/App/TaskTickApp.swift
@@ -20,7 +20,23 @@ struct TaskTickApp: App {
         let container = Self._sharedModelContainer
         let scheduler = TaskScheduler.shared
         scheduler.configure(modelContext: container.mainContext)
-        scheduler.start()
+
+        let logRetention = ExecutionLogRetentionManager.shared
+        logRetention.configure(modelContainer: container)
+        Task { @MainActor in
+            let result = await logRetention.runAutomaticCleanup()
+            if result.deletedCount > 0 {
+                NSLog(
+                    "Automatic log cleanup deleted \(result.deletedCount) log(s) "
+                        + "from \(result.affectedTaskCount) task(s)"
+                )
+            }
+            // Existing stores may contain hundreds of thousands of logs. Do not
+            // let the scheduler touch their relationships until startup cleanup
+            // has reduced them to the configured bounds.
+            scheduler.start()
+            logRetention.startPeriodicCleanup()
+        }
 
         let backup = DatabaseBackup.shared
         backup.configure(storeURL: Self._storeURL, modelContext: container.mainContext)

--- a/Sources/Engine/ExecutionLogRetention.swift
+++ b/Sources/Engine/ExecutionLogRetention.swift
@@ -1,0 +1,222 @@
+import Foundation
+import SwiftData
+import TaskTickCore
+
+struct ExecutionLogRetentionPolicy: Sendable, Equatable {
+    static let automaticCleanupKey = "logs.automaticCleanup"
+    static let retentionDaysKey = "logRetentionDays"
+    static let maximumLogsPerTaskKey = "logs.maximumPerTask"
+
+    static let defaultAutomaticCleanup = true
+    static let defaultRetentionDays = 30
+    static let defaultMaximumLogsPerTask = 1_000
+
+    let retentionDays: Int
+    let maximumLogsPerTask: Int
+
+    init(retentionDays: Int, maximumLogsPerTask: Int) {
+        self.retentionDays = max(retentionDays, 0)
+        self.maximumLogsPerTask = max(maximumLogsPerTask, 1)
+    }
+
+    static func current(defaults: UserDefaults = .standard) -> Self {
+        let retentionDays = defaults.object(forKey: retentionDaysKey) as? Int
+            ?? defaultRetentionDays
+        let maximumLogsPerTask = defaults.object(forKey: maximumLogsPerTaskKey) as? Int
+            ?? defaultMaximumLogsPerTask
+        return Self(
+            retentionDays: retentionDays,
+            maximumLogsPerTask: maximumLogsPerTask
+        )
+    }
+
+    static func isAutomaticCleanupEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: automaticCleanupKey) as? Bool ?? defaultAutomaticCleanup
+    }
+}
+
+struct ExecutionLogCleanupResult: Sendable, Equatable {
+    var deletedCount = 0
+    var affectedTaskCount = 0
+}
+
+enum ExecutionLogRetention {
+    /// Applies both age and per-task count limits without ever deleting a live run.
+    ///
+    /// Automatic cleanup skips `afterCount` tasks because their retained log count is
+    /// currently also the scheduler's source of truth for the end condition. Manual
+    /// cleanup keeps the existing behavior and may include them after user confirmation.
+    static func cleanup(
+        in context: ModelContext,
+        policy: ExecutionLogRetentionPolicy,
+        now: Date = Date(),
+        skipCountLimitedTasks: Bool
+    ) throws -> ExecutionLogCleanupResult {
+        let tasks = try context.fetch(FetchDescriptor<ScheduledTask>())
+        let cutoff = Calendar.current.date(
+            byAdding: .day,
+            value: -policy.retentionDays,
+            to: now
+        ) ?? now
+        let runningRaw = ExecutionStatus.running.rawValue
+        let afterCountRaw = EndRepeatType.afterCount.rawValue
+        var result = ExecutionLogCleanupResult()
+
+        for task in tasks {
+            if skipCountLimitedTasks && task.endRepeatTypeRaw == afterCountRaw {
+                continue
+            }
+
+            let taskID = task.id
+            var deletedForTask = 0
+
+            let expiredPredicate = #Predicate<ExecutionLog> { log in
+                log.task?.id == taskID
+                    && log.statusRaw != runningRaw
+                    && log.startedAt < cutoff
+            }
+            let expiredDescriptor = FetchDescriptor<ExecutionLog>(predicate: expiredPredicate)
+            deletedForTask += try delete(expiredDescriptor, in: context)
+
+            var boundaryDescriptor = FetchDescriptor<ExecutionLog>(
+                predicate: #Predicate { log in
+                    log.task?.id == taskID && log.statusRaw != runningRaw
+                },
+                sortBy: [SortDescriptor(\ExecutionLog.startedAt, order: .reverse)]
+            )
+            boundaryDescriptor.fetchOffset = policy.maximumLogsPerTask - 1
+            boundaryDescriptor.fetchLimit = 1
+
+            if let oldestKept = try context.fetch(boundaryDescriptor).first {
+                let boundary = oldestKept.startedAt
+                let olderPredicate = #Predicate<ExecutionLog> { log in
+                    log.task?.id == taskID
+                        && log.statusRaw != runningRaw
+                        && log.startedAt < boundary
+                }
+                let olderDescriptor = FetchDescriptor<ExecutionLog>(predicate: olderPredicate)
+                deletedForTask += try delete(olderDescriptor, in: context)
+
+                // Preserve an exact limit when multiple runs have the same timestamp.
+                var tiedExcessDescriptor = FetchDescriptor<ExecutionLog>(
+                    predicate: #Predicate { log in
+                        log.task?.id == taskID && log.statusRaw != runningRaw
+                    },
+                    sortBy: [SortDescriptor(\ExecutionLog.startedAt, order: .reverse)]
+                )
+                tiedExcessDescriptor.fetchOffset = policy.maximumLogsPerTask
+                deletedForTask += try delete(tiedExcessDescriptor, in: context)
+            }
+
+            guard deletedForTask > 0 else { continue }
+
+            let remainingDescriptor = FetchDescriptor<ExecutionLog>(
+                predicate: #Predicate { $0.task?.id == taskID }
+            )
+            task.executionCount = try context.fetchCount(remainingDescriptor)
+            result.deletedCount += deletedForTask
+            result.affectedTaskCount += 1
+        }
+
+        if result.affectedTaskCount > 0 {
+            try context.save()
+        }
+        return result
+    }
+
+    private static func delete(
+        _ descriptor: FetchDescriptor<ExecutionLog>,
+        in context: ModelContext
+    ) throws -> Int {
+        var deletedCount = 0
+        var batchDescriptor = descriptor
+        batchDescriptor.fetchLimit = 500
+
+        while true {
+            let batch = try context.fetch(batchDescriptor)
+            guard !batch.isEmpty else { break }
+            for log in batch {
+                context.delete(log)
+            }
+            try context.save()
+            deletedCount += batch.count
+        }
+        return deletedCount
+    }
+}
+
+@MainActor
+final class ExecutionLogRetentionManager {
+    static let shared = ExecutionLogRetentionManager()
+    static let cleanupInterval: Duration = .seconds(24 * 60 * 60)
+
+    private var modelContainer: ModelContainer?
+    private var periodicTask: Task<Void, Never>?
+    private var activeCleanup: Task<ExecutionLogCleanupResult, Never>?
+
+    private init() {}
+
+    func configure(modelContainer: ModelContainer) {
+        self.modelContainer = modelContainer
+    }
+
+    func runAutomaticCleanup() async -> ExecutionLogCleanupResult {
+        guard ExecutionLogRetentionPolicy.isAutomaticCleanupEnabled() else {
+            return ExecutionLogCleanupResult()
+        }
+        return await cleanup(skipCountLimitedTasks: true)
+    }
+
+    func runManualCleanup() async -> ExecutionLogCleanupResult {
+        await cleanup(skipCountLimitedTasks: false)
+    }
+
+    func startPeriodicCleanup() {
+        periodicTask?.cancel()
+        periodicTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: Self.cleanupInterval)
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled else { return }
+                _ = await self?.runAutomaticCleanup()
+            }
+        }
+    }
+
+    func stop() {
+        periodicTask?.cancel()
+        periodicTask = nil
+        activeCleanup?.cancel()
+        activeCleanup = nil
+    }
+
+    private func cleanup(skipCountLimitedTasks: Bool) async -> ExecutionLogCleanupResult {
+        if let activeCleanup {
+            return await activeCleanup.value
+        }
+        guard let modelContainer else { return ExecutionLogCleanupResult() }
+
+        let policy = ExecutionLogRetentionPolicy.current()
+        let cleanupTask = Task.detached(priority: .utility) {
+            do {
+                let context = ModelContext(modelContainer)
+                context.autosaveEnabled = false
+                return try ExecutionLogRetention.cleanup(
+                    in: context,
+                    policy: policy,
+                    skipCountLimitedTasks: skipCountLimitedTasks
+                )
+            } catch {
+                NSLog("Execution-log cleanup failed: \(error.localizedDescription)")
+                return ExecutionLogCleanupResult()
+            }
+        }
+        activeCleanup = cleanupTask
+        let result = await cleanupTask.value
+        activeCleanup = nil
+        return result
+    }
+}

--- a/Sources/Engine/LogDeletion.swift
+++ b/Sources/Engine/LogDeletion.swift
@@ -5,8 +5,8 @@ import TaskTickCore
 /// Shared delete path for execution logs removed from the log lists.
 ///
 /// Deleting logs is not just a `modelContext.delete` — `ScheduledTask`
-/// carries a denormalized `executionCount`, and `computeNextRunDate` reads
-/// `executionLogs.count` for run-count-limited schedules. Both must be
+/// carries a denormalized `executionCount`, and `computeNextRunDate` reads it
+/// for run-count-limited schedules. Both the counter and next date must be
 /// resynced or a task can stall (thinking it already hit its run cap) or
 /// report a count that no longer matches its logs. The existing "clear all
 /// logs" flows in `TaskListView` / `TaskDetailView` do the same three steps;

--- a/Sources/Engine/ScriptExecutor.swift
+++ b/Sources/Engine/ScriptExecutor.swift
@@ -98,6 +98,9 @@ final class ScriptExecutor: ObservableObject {
 
         let log = ExecutionLog(task: task, triggeredBy: triggeredBy)
         modelContext.insert(log)
+        // Keep this denormalized counter hot-path friendly. The scheduler and UI
+        // must not fault and walk an unbounded to-many relationship on every run.
+        task.executionCount += 1
         let startTime = Date()
         // Bump the manual-run recency NOW (not at end) so long-running scripts
         // — dev servers, watchers, anything that runs for hours — surface to
@@ -245,11 +248,6 @@ final class ScriptExecutor: ObservableObject {
             // Note: lastManualRunAt is set at task START (above) so running
             // scripts surface immediately. No need to update it again here.
             fetchedTask.updatedAt = endTime
-            // Keep executionCount in sync for both manual and scheduled runs so the UI
-            // badge and any downstream checks reflect actual completed executions.
-            fetchedTask.executionCount = fetchedTask.executionLogs
-                .filter { $0.modelContext != nil }
-                .count
         }
 
         do { try modelContext.save() } catch { NSLog("⚠️ ScriptExecutor save failed: \(error)") }

--- a/Sources/Engine/TaskScheduler.swift
+++ b/Sources/Engine/TaskScheduler.swift
@@ -225,14 +225,12 @@ final class TaskScheduler: ObservableObject {
 
         runningTaskIDs.insert(taskId)
 
-        // Sync executionCount with actual log count, skipping invalidated references
-        let validLogCount = task.executionLogs.filter { $0.modelContext != nil }.count
-        task.executionCount = validLogCount + 1 // +1 for current execution
-
         // Check end repeat count directly before computing next date
+        // ScriptExecutor increments executionCount when it inserts this run's log.
+        let nextExecutionCount = task.executionCount + 1
         if task.endRepeatType == .afterCount,
            let maxCount = task.endRepeatCount,
-           task.executionCount >= maxCount {
+           nextExecutionCount >= maxCount {
             task.nextRunAt = nil
             task.isEnabled = false
         } else {
@@ -284,10 +282,9 @@ final class TaskScheduler: ObservableObject {
         }
 
         // Check end repeat count first (applies to all schedule types)
-        // Use executionLogs.count as source of truth for completed executions
         if task.endRepeatType == .afterCount,
            let maxCount = task.endRepeatCount,
-           task.executionLogs.filter({ $0.modelContext != nil }).count >= maxCount {
+           task.executionCount >= maxCount {
             return nil
         }
         if task.endRepeatType == .onDate,
@@ -425,7 +422,7 @@ final class TaskScheduler: ObservableObject {
             return candidate
         case .afterCount:
             if let maxCount = task.endRepeatCount,
-               task.executionLogs.filter({ $0.modelContext != nil }).count >= maxCount {
+               task.executionCount >= maxCount {
                 return nil
             }
             return candidate
@@ -477,7 +474,7 @@ final class TaskScheduler: ObservableObject {
         }
 
         var occurrenceDay = calendar.startOfDay(for: scheduledDate)
-        let logCount = task.executionLogs.filter { $0.modelContext != nil }.count
+        let logCount = task.executionCount
 
         // ~2 years of daily steps, ~15 years of weekly. Pathological configs
         // (e.g. end-on-date in the distant past with stride misaligned) bail

--- a/Sources/TaskTickCore/Localization/de.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/de.lproj/Localizable.strings
@@ -447,9 +447,11 @@
 "settings.logs.section" = "Protokollverwaltung";
 "settings.logs.retention" = "Aufbewahrungsdauer";
 "settings.logs.retention.days" = "Tage";
+"settings.logs.automatic_cleanup" = "Protokolle automatisch bereinigen";
+"settings.logs.maximum_per_task" = "Maximale Protokolle pro Aufgabe";
 "settings.logs.cleanup" = "Alte Protokolle bereinigen";
 "settings.logs.cleanup.confirm.title" = "Alte Protokolle bereinigen?";
-"settings.logs.cleanup.confirm.message" = "Alle Ausführungsprotokolle, die älter als %d Tage sind, werden dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.";
+"settings.logs.cleanup.confirm.message" = "Ausführungsprotokolle, die älter als %d Tage sind oder die neuesten %d pro Aufgabe überschreiten, werden dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.";
 "settings.logs.cleanup.cancel" = "Abbrechen";
 "settings.logs.cleanup.confirm" = "Bereinigen";
 "settings.logs.cleanup.result.title" = "Bereinigung abgeschlossen";

--- a/Sources/TaskTickCore/Localization/en.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/en.lproj/Localizable.strings
@@ -447,9 +447,11 @@
 "settings.logs.section" = "Log Management";
 "settings.logs.retention" = "Retention Period";
 "settings.logs.retention.days" = "days";
+"settings.logs.automatic_cleanup" = "Clean Up Logs Automatically";
+"settings.logs.maximum_per_task" = "Maximum Logs per Task";
 "settings.logs.cleanup" = "Clean Up Old Logs";
 "settings.logs.cleanup.confirm.title" = "Clean Up Old Logs?";
-"settings.logs.cleanup.confirm.message" = "All execution logs older than %d days will be permanently deleted. This action cannot be undone.";
+"settings.logs.cleanup.confirm.message" = "Execution logs older than %d days or beyond the newest %d logs per task will be permanently deleted. This action cannot be undone.";
 "settings.logs.cleanup.cancel" = "Cancel";
 "settings.logs.cleanup.confirm" = "Clean Up";
 "settings.logs.cleanup.result.title" = "Cleanup Complete";

--- a/Sources/TaskTickCore/Localization/es.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/es.lproj/Localizable.strings
@@ -447,9 +447,11 @@
 "settings.logs.section" = "Gestión de registros";
 "settings.logs.retention" = "Período de retención";
 "settings.logs.retention.days" = "días";
+"settings.logs.automatic_cleanup" = "Limpiar registros automáticamente";
+"settings.logs.maximum_per_task" = "Máximo de registros por tarea";
 "settings.logs.cleanup" = "Limpiar registros antiguos";
 "settings.logs.cleanup.confirm.title" = "¿Limpiar registros antiguos?";
-"settings.logs.cleanup.confirm.message" = "Todos los registros de ejecución de más de %d días se eliminarán permanentemente. Esta acción no se puede deshacer.";
+"settings.logs.cleanup.confirm.message" = "Los registros de más de %d días o que superen los %d más recientes por tarea se eliminarán permanentemente. Esta acción no se puede deshacer.";
 "settings.logs.cleanup.cancel" = "Cancelar";
 "settings.logs.cleanup.confirm" = "Limpiar";
 "settings.logs.cleanup.result.title" = "Limpieza completada";

--- a/Sources/TaskTickCore/Localization/fr.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/fr.lproj/Localizable.strings
@@ -414,9 +414,11 @@
 "settings.logs.section" = "Gestion des journaux";
 "settings.logs.retention" = "Période de conservation";
 "settings.logs.retention.days" = "jours";
+"settings.logs.automatic_cleanup" = "Nettoyer les journaux automatiquement";
+"settings.logs.maximum_per_task" = "Maximum de journaux par tâche";
 "settings.logs.cleanup" = "Nettoyer les anciens journaux";
 "settings.logs.cleanup.confirm.title" = "Nettoyer les anciens journaux ?";
-"settings.logs.cleanup.confirm.message" = "Tous les journaux d'exécution datant de plus de %d jours seront définitivement supprimés. Cette action est irréversible.";
+"settings.logs.cleanup.confirm.message" = "Les journaux datant de plus de %d jours ou dépassant les %d plus récents par tâche seront définitivement supprimés. Cette action est irréversible.";
 "settings.logs.cleanup.cancel" = "Annuler";
 "settings.logs.cleanup.confirm" = "Nettoyer";
 "settings.logs.cleanup.result.title" = "Nettoyage terminé";

--- a/Sources/TaskTickCore/Localization/id.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/id.lproj/Localizable.strings
@@ -447,9 +447,11 @@
 "settings.logs.section" = "Manajemen Log";
 "settings.logs.retention" = "Periode Penyimpanan";
 "settings.logs.retention.days" = "hari";
+"settings.logs.automatic_cleanup" = "Bersihkan Log Secara Otomatis";
+"settings.logs.maximum_per_task" = "Maksimum Log per Tugas";
 "settings.logs.cleanup" = "Bersihkan Log Lama";
 "settings.logs.cleanup.confirm.title" = "Bersihkan Log Lama?";
-"settings.logs.cleanup.confirm.message" = "Semua log eksekusi yang lebih lama dari %d hari akan dihapus secara permanen. Tindakan ini tidak dapat dibatalkan.";
+"settings.logs.cleanup.confirm.message" = "Log yang lebih lama dari %d hari atau melebihi %d log terbaru per tugas akan dihapus permanen. Tindakan ini tidak dapat dibatalkan.";
 "settings.logs.cleanup.cancel" = "Batal";
 "settings.logs.cleanup.confirm" = "Bersihkan";
 "settings.logs.cleanup.result.title" = "Pembersihan Selesai";

--- a/Sources/TaskTickCore/Localization/it.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/it.lproj/Localizable.strings
@@ -447,9 +447,11 @@
 "settings.logs.section" = "Gestione registri";
 "settings.logs.retention" = "Periodo di conservazione";
 "settings.logs.retention.days" = "giorni";
+"settings.logs.automatic_cleanup" = "Elimina automaticamente i registri";
+"settings.logs.maximum_per_task" = "Registri massimi per attività";
 "settings.logs.cleanup" = "Elimina registri vecchi";
 "settings.logs.cleanup.confirm.title" = "Eliminare i registri vecchi?";
-"settings.logs.cleanup.confirm.message" = "Tutti i registri di esecuzione più vecchi di %d giorni verranno eliminati definitivamente. L'azione non può essere annullata.";
+"settings.logs.cleanup.confirm.message" = "I registri più vecchi di %d giorni o oltre i %d più recenti per attività verranno eliminati definitivamente. L'azione non può essere annullata.";
 "settings.logs.cleanup.cancel" = "Annulla";
 "settings.logs.cleanup.confirm" = "Elimina";
 "settings.logs.cleanup.result.title" = "Pulizia completata";

--- a/Sources/TaskTickCore/Localization/ja.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/ja.lproj/Localizable.strings
@@ -447,9 +447,11 @@
 "settings.logs.section" = "ログ管理";
 "settings.logs.retention" = "保持期間";
 "settings.logs.retention.days" = "日";
+"settings.logs.automatic_cleanup" = "実行ログを自動的に削除";
+"settings.logs.maximum_per_task" = "タスクごとの最大ログ数";
 "settings.logs.cleanup" = "古いログを削除";
 "settings.logs.cleanup.confirm.title" = "古いログを削除しますか？";
-"settings.logs.cleanup.confirm.message" = "%d 日より前の実行ログはすべて完全に削除されます。この操作は取り消せません。";
+"settings.logs.cleanup.confirm.message" = "%d 日より前、またはタスクごとの最新 %d 件を超える実行ログは完全に削除されます。この操作は取り消せません。";
 "settings.logs.cleanup.cancel" = "キャンセル";
 "settings.logs.cleanup.confirm" = "削除";
 "settings.logs.cleanup.result.title" = "クリーンアップ完了";

--- a/Sources/TaskTickCore/Localization/ko.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/ko.lproj/Localizable.strings
@@ -447,9 +447,11 @@
 "settings.logs.section" = "로그 관리";
 "settings.logs.retention" = "보관 기간";
 "settings.logs.retention.days" = "일";
+"settings.logs.automatic_cleanup" = "실행 로그 자동 정리";
+"settings.logs.maximum_per_task" = "작업당 최대 로그 수";
 "settings.logs.cleanup" = "오래된 로그 정리";
 "settings.logs.cleanup.confirm.title" = "오래된 로그를 정리하시겠습니까?";
-"settings.logs.cleanup.confirm.message" = "%d일보다 오래된 모든 실행 로그가 영구적으로 삭제됩니다. 이 작업은 되돌릴 수 없습니다.";
+"settings.logs.cleanup.confirm.message" = "%d일보다 오래되었거나 작업당 최신 %d개를 초과한 실행 로그가 영구적으로 삭제됩니다. 이 작업은 되돌릴 수 없습니다.";
 "settings.logs.cleanup.cancel" = "취소";
 "settings.logs.cleanup.confirm" = "정리";
 "settings.logs.cleanup.result.title" = "정리 완료";

--- a/Sources/TaskTickCore/Localization/ru.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/ru.lproj/Localizable.strings
@@ -447,9 +447,11 @@
 "settings.logs.section" = "Управление журналом";
 "settings.logs.retention" = "Срок хранения";
 "settings.logs.retention.days" = "дней";
+"settings.logs.automatic_cleanup" = "Автоматически очищать журналы";
+"settings.logs.maximum_per_task" = "Максимум журналов на задачу";
 "settings.logs.cleanup" = "Очистить старые записи";
 "settings.logs.cleanup.confirm.title" = "Очистить старые записи?";
-"settings.logs.cleanup.confirm.message" = "Все записи о выполнении старше %d дней будут удалены навсегда. Это действие нельзя отменить.";
+"settings.logs.cleanup.confirm.message" = "Записи старше %d дней или сверх последних %d на задачу будут удалены навсегда. Это действие нельзя отменить.";
 "settings.logs.cleanup.cancel" = "Отмена";
 "settings.logs.cleanup.confirm" = "Очистить";
 "settings.logs.cleanup.result.title" = "Очистка завершена";

--- a/Sources/TaskTickCore/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/zh-Hans.lproj/Localizable.strings
@@ -447,9 +447,11 @@
 "settings.logs.section" = "日志管理";
 "settings.logs.retention" = "保留期限";
 "settings.logs.retention.days" = "天";
+"settings.logs.automatic_cleanup" = "自动清理执行日志";
+"settings.logs.maximum_per_task" = "每个任务最多保留";
 "settings.logs.cleanup" = "清理历史日志";
 "settings.logs.cleanup.confirm.title" = "清理历史日志？";
-"settings.logs.cleanup.confirm.message" = "早于 %d 天的执行日志将被永久删除，此操作不可撤销。";
+"settings.logs.cleanup.confirm.message" = "早于 %d 天或超出每个任务最新 %d 条的执行日志将被永久删除，此操作不可撤销。";
 "settings.logs.cleanup.cancel" = "取消";
 "settings.logs.cleanup.confirm" = "清理";
 "settings.logs.cleanup.result.title" = "清理完成";

--- a/Sources/TaskTickCore/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Sources/TaskTickCore/Localization/zh-Hant.lproj/Localizable.strings
@@ -447,9 +447,11 @@
 "settings.logs.section" = "日誌管理";
 "settings.logs.retention" = "保留期限";
 "settings.logs.retention.days" = "天";
+"settings.logs.automatic_cleanup" = "自動清理執行日誌";
+"settings.logs.maximum_per_task" = "每個任務最多保留";
 "settings.logs.cleanup" = "清理歷史日誌";
 "settings.logs.cleanup.confirm.title" = "清理歷史日誌？";
-"settings.logs.cleanup.confirm.message" = "早於 %d 天的執行日誌將被永久刪除，此操作無法復原。";
+"settings.logs.cleanup.confirm.message" = "早於 %d 天或超出每個任務最新 %d 筆的執行日誌將被永久刪除，此操作無法復原。";
 "settings.logs.cleanup.cancel" = "取消";
 "settings.logs.cleanup.confirm" = "清理";
 "settings.logs.cleanup.result.title" = "清理完成";

--- a/Sources/Views/Settings/SettingsView.swift
+++ b/Sources/Views/Settings/SettingsView.swift
@@ -16,7 +16,12 @@ struct SettingsView: View {
     @AppStorage("notificationsEnabled") private var notificationsEnabled = true
 
     // Logs
-    @AppStorage("logRetentionDays") private var logRetentionDays = 30
+    @AppStorage(ExecutionLogRetentionPolicy.automaticCleanupKey)
+    private var automaticLogCleanup = ExecutionLogRetentionPolicy.defaultAutomaticCleanup
+    @AppStorage(ExecutionLogRetentionPolicy.retentionDaysKey)
+    private var logRetentionDays = ExecutionLogRetentionPolicy.defaultRetentionDays
+    @AppStorage(ExecutionLogRetentionPolicy.maximumLogsPerTaskKey)
+    private var maximumLogsPerTask = ExecutionLogRetentionPolicy.defaultMaximumLogsPerTask
     @AppStorage("logs.streamManualToFile") private var streamManualToFile = true
 
     // Updates
@@ -567,6 +572,11 @@ struct SettingsView: View {
     private var logsTab: some View {
         Form {
             Section(L10n.tr("settings.logs.section")) {
+                Toggle(
+                    L10n.tr("settings.logs.automatic_cleanup"),
+                    isOn: $automaticLogCleanup
+                )
+
                 LabeledContent(L10n.tr("settings.logs.retention")) {
                     HStack(spacing: 6) {
                         TextField("", value: $logRetentionDays, format: .number)
@@ -576,6 +586,13 @@ struct SettingsView: View {
                         Text(L10n.tr("settings.logs.retention.days"))
                             .foregroundStyle(.secondary)
                     }
+                }
+
+                LabeledContent(L10n.tr("settings.logs.maximum_per_task")) {
+                    TextField("", value: $maximumLogsPerTask, format: .number)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 80)
+                        .multilineTextAlignment(.trailing)
                 }
 
                 HStack(spacing: 8) {
@@ -622,7 +639,11 @@ struct SettingsView: View {
                 runLogCleanup()
             }
         } message: {
-            Text(L10n.tr("settings.logs.cleanup.confirm.message", logRetentionDays))
+            Text(L10n.tr(
+                "settings.logs.cleanup.confirm.message",
+                max(logRetentionDays, 0),
+                max(maximumLogsPerTask, 1)
+            ))
         }
         .alert(L10n.tr("settings.logs.cleanup.result.title"), isPresented: $showCleanupResult) {
             Button("OK") {}
@@ -632,40 +653,16 @@ struct SettingsView: View {
     }
 
     private func runLogCleanup() {
-        let days = max(logRetentionDays, 0)
-        let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: Date()) ?? Date()
-        let container = TaskTickApp._sharedModelContainer
-
         isCleaningLogs = true
         Task {
-            // Heavy work on a background ModelContext so the setting window stays
-            // responsive even when the user has accumulated tens of thousands of
-            // execution logs. The background save propagates through the shared
-            // container; main-context @Query subscribers refresh automatically.
-            let deleted = await Task.detached(priority: .userInitiated) {
-                let ctx = ModelContext(container)
-                let descriptor = FetchDescriptor<ExecutionLog>(
-                    predicate: #Predicate { $0.startedAt < cutoff }
-                )
-                guard let logs = try? ctx.fetch(descriptor), !logs.isEmpty else { return 0 }
-                let count = logs.count
-                for log in logs { ctx.delete(log) }
-
-                // Keep each task's stored `executionCount` aligned with its remaining
-                // logs — other UI (detail view badge, end-after-count end condition)
-                // reads from this field and would otherwise show stale totals.
-                if let tasks = try? ctx.fetch(FetchDescriptor<ScheduledTask>()) {
-                    for t in tasks {
-                        t.executionCount = t.executionLogs.filter { $0.modelContext != nil }.count
-                    }
-                }
-                do { try ctx.save() } catch { return 0 }
-                return count
-            }.value
+            let result = await ExecutionLogRetentionManager.shared.runManualCleanup()
 
             isCleaningLogs = false
-            cleanupDeletedCount = deleted
+            cleanupDeletedCount = result.deletedCount
             showCleanupResult = true
+            if result.deletedCount > 0 {
+                TaskScheduler.shared.rebuildSchedule()
+            }
         }
     }
 

--- a/Tests/AppTests/ExecutionLogRetentionTests.swift
+++ b/Tests/AppTests/ExecutionLogRetentionTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import SwiftData
+import Testing
+import TaskTickCore
+@testable import TaskTickApp
+
+@Suite("Execution log retention")
+@MainActor
+struct ExecutionLogRetentionTests {
+    private func makeContext() throws -> (ModelContainer, ModelContext) {
+        let schema = Schema([ScheduledTask.self, ExecutionLog.self])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [configuration])
+        return (container, container.mainContext)
+    }
+
+    @discardableResult
+    private func insertLog(
+        for task: ScheduledTask,
+        at date: Date,
+        status: ExecutionStatus = .success,
+        in context: ModelContext
+    ) -> ExecutionLog {
+        let log = ExecutionLog(task: task)
+        log.startedAt = date
+        log.status = status
+        if status != .running {
+            log.finishedAt = date.addingTimeInterval(1)
+        }
+        context.insert(log)
+        return log
+    }
+
+    @Test("Defaults are automatic, 30 days, and 1,000 logs per task")
+    func policyDefaultsAndClamping() {
+        let suiteName = "ExecutionLogRetentionTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(ExecutionLogRetentionPolicy.isAutomaticCleanupEnabled(defaults: defaults))
+        #expect(ExecutionLogRetentionPolicy.current(defaults: defaults) == .init(
+            retentionDays: 30,
+            maximumLogsPerTask: 1_000
+        ))
+
+        defaults.set(-2, forKey: ExecutionLogRetentionPolicy.retentionDaysKey)
+        defaults.set(0, forKey: ExecutionLogRetentionPolicy.maximumLogsPerTaskKey)
+        #expect(ExecutionLogRetentionPolicy.current(defaults: defaults) == .init(
+            retentionDays: 0,
+            maximumLogsPerTask: 1
+        ))
+    }
+
+    @Test("Automatic cleanup applies age and count limits but preserves running logs")
+    func automaticCleanupPrunesBoundedTasks() throws {
+        let (container, context) = try makeContext()
+        _ = container
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let task = ScheduledTask(name: "frequent")
+        context.insert(task)
+
+        insertLog(for: task, at: now.addingTimeInterval(-40 * 86_400), in: context)
+        for hoursAgo in 1...5 {
+            insertLog(for: task, at: now.addingTimeInterval(TimeInterval(-hoursAgo * 3_600)), in: context)
+        }
+        let running = insertLog(
+            for: task,
+            at: now.addingTimeInterval(-60 * 86_400),
+            status: .running,
+            in: context
+        )
+        task.executionCount = 99
+        try context.save()
+
+        let result = try ExecutionLogRetention.cleanup(
+            in: context,
+            policy: .init(retentionDays: 30, maximumLogsPerTask: 3),
+            now: now,
+            skipCountLimitedTasks: true
+        )
+
+        let taskID = task.id
+        let remaining = try context.fetch(FetchDescriptor<ExecutionLog>(
+            predicate: #Predicate { $0.task?.id == taskID },
+            sortBy: [SortDescriptor(\ExecutionLog.startedAt, order: .reverse)]
+        ))
+        #expect(result == ExecutionLogCleanupResult(deletedCount: 3, affectedTaskCount: 1))
+        #expect(remaining.count == 4)
+        #expect(remaining.contains { $0.id == running.id })
+        #expect(remaining.filter { $0.status != .running }.map(\.startedAt) == [
+            now.addingTimeInterval(-3_600),
+            now.addingTimeInterval(-2 * 3_600),
+            now.addingTimeInterval(-3 * 3_600),
+        ])
+        #expect(task.executionCount == 4)
+    }
+
+    @Test("Count pruning continues across multiple 500-row batches")
+    func countPruningUsesMultipleBatches() throws {
+        let (container, context) = try makeContext()
+        _ = container
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let task = ScheduledTask(name: "burst")
+        context.insert(task)
+        for offset in 0..<510 {
+            insertLog(
+                for: task,
+                at: now.addingTimeInterval(TimeInterval(-offset)),
+                in: context
+            )
+        }
+        task.executionCount = 510
+        try context.save()
+
+        let result = try ExecutionLogRetention.cleanup(
+            in: context,
+            policy: .init(retentionDays: 365, maximumLogsPerTask: 5),
+            now: now,
+            skipCountLimitedTasks: true
+        )
+
+        let taskID = task.id
+        let remaining = try context.fetchCount(FetchDescriptor<ExecutionLog>(
+            predicate: #Predicate { $0.task?.id == taskID }
+        ))
+        #expect(result.deletedCount == 505)
+        #expect(remaining == 5)
+        #expect(task.executionCount == 5)
+    }
+
+    @Test("Automatic cleanup skips tasks whose schedule ends after a run count")
+    func automaticCleanupSkipsAfterCountTasks() throws {
+        let (container, context) = try makeContext()
+        _ = container
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let task = ScheduledTask(name: "bounded")
+        task.endRepeatType = .afterCount
+        task.endRepeatCount = 10
+        context.insert(task)
+        for daysAgo in 40...44 {
+            insertLog(for: task, at: now.addingTimeInterval(TimeInterval(-daysAgo * 86_400)), in: context)
+        }
+        task.executionCount = 5
+        try context.save()
+
+        let result = try ExecutionLogRetention.cleanup(
+            in: context,
+            policy: .init(retentionDays: 30, maximumLogsPerTask: 2),
+            now: now,
+            skipCountLimitedTasks: true
+        )
+
+        #expect(result.deletedCount == 0)
+        #expect(task.executionLogs.count == 5)
+        #expect(task.executionCount == 5)
+    }
+
+    @Test("Confirmed manual cleanup also applies to after-count tasks")
+    func manualCleanupIncludesAfterCountTasks() throws {
+        let (container, context) = try makeContext()
+        _ = container
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let task = ScheduledTask(name: "bounded")
+        task.endRepeatType = .afterCount
+        task.endRepeatCount = 10
+        context.insert(task)
+        insertLog(for: task, at: now.addingTimeInterval(-40 * 86_400), in: context)
+        insertLog(for: task, at: now.addingTimeInterval(-41 * 86_400), in: context)
+        task.executionCount = 2
+        try context.save()
+
+        let result = try ExecutionLogRetention.cleanup(
+            in: context,
+            policy: .init(retentionDays: 30, maximumLogsPerTask: 10),
+            now: now,
+            skipCountLimitedTasks: false
+        )
+
+        #expect(result.deletedCount == 2)
+        #expect(task.executionCount == 0)
+    }
+}

--- a/Tests/AppTests/ScriptExecutorTests.swift
+++ b/Tests/AppTests/ScriptExecutorTests.swift
@@ -1,5 +1,7 @@
 import Testing
 import Foundation
+import SwiftData
+import TaskTickCore
 @testable import TaskTickApp
 
 @Suite("ScriptExecutor Tests")
@@ -10,6 +12,26 @@ struct ScriptExecutorTests {
     func executorExists() {
         let executor = ScriptExecutor.shared
         #expect(executor != nil)
+    }
+
+    @Test("Executing a task increments its stored log counter")
+    @MainActor
+    func executionIncrementsStoredCounter() async throws {
+        let schema = Schema([ScheduledTask.self, ExecutionLog.self])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [configuration])
+        let context = container.mainContext
+        let task = ScheduledTask(name: "counter", scriptBody: "printf ok")
+        task.notifyOnSuccess = false
+        task.notifyOnFailure = false
+        context.insert(task)
+        try context.save()
+
+        let log = await ScriptExecutor.shared.execute(task: task, modelContext: context)
+
+        #expect(log.status == .success)
+        #expect(task.executionCount == 1)
+        #expect(task.executionLogs.count == 1)
     }
 
     /// Reproduces the ipcheck output-truncation bug: runs the same ipcheck

--- a/Tests/AppTests/TaskSchedulerTests.swift
+++ b/Tests/AppTests/TaskSchedulerTests.swift
@@ -56,6 +56,25 @@ struct TaskSchedulerTests {
         }
     }
 
+    @Test("After-count schedules use the stored execution counter")
+    @MainActor
+    func afterCountUsesStoredExecutionCount() {
+        let task = ScheduledTask(
+            name: "bounded",
+            scriptBody: "echo hi",
+            scheduledDate: Date(),
+            repeatType: .everyMinute,
+            endRepeatType: .afterCount,
+            endRepeatCount: 3
+        )
+        task.executionCount = 3
+
+        #expect(TaskScheduler.shared.computeNextRunDate(for: task) == nil)
+
+        task.executionCount = 2
+        #expect(TaskScheduler.shared.computeNextRunDate(for: task) != nil)
+    }
+
     // Shortcut tasks share the same scheduling pipeline as shell tasks —
     // setting shortcutName must not block computeNextRunDate from picking
     // up a normal repeat schedule.


### PR DESCRIPTION
## Summary

- automatically enforce the configured retention period at launch and every 24 hours
- add a configurable per-task history cap (default: 1,000) and an automatic-cleanup toggle
- prune in 500-row background batches, preserve running logs, and delay scheduler startup until the initial cleanup completes
- skip `afterCount` tasks during automatic cleanup so pruning cannot change their end condition; confirmed manual cleanup retains the existing behavior
- replace scheduler/executor relationship-wide log counts with the persisted `executionCount` hot path
- localize the new settings across all 11 existing localizations

## Why

High-frequency tasks can accumulate hundreds of thousands of `ExecutionLog` rows. The scheduler and detail UI then fault and traverse the unbounded `executionLogs` relationship, keeping the main thread at 100% CPU and making the app unresponsive. The existing retention value is only applied when the user manually presses the cleanup button.

## Verification

- `swift test --filter "(ExecutionLogRetentionTests|LocalizationFilesTests|TaskSchedulerTests|ScriptExecutorTests)"` (25 tests passed)
- retention coverage includes age pruning, exact per-task caps across multiple 500-row batches, running-log preservation, and `afterCount` protection
- `./scripts/build-dev.sh` successfully built, signed, installed, and launched `TaskTick Dev.app`
- visually verified the Logs settings page: automatic cleanup enabled, 30-day retention, and 1,000-log cap
- verified a real every-minute task run: UI count 1, SQLite count 1, status `success`, idle CPU 0%

## Existing test noise

A full `swift test` run completes all added tests successfully; the only failures are the repository's pre-existing timing-sensitive `FileWatcherTests` (5 issues). No retention, scheduler, localization, or executor test fails.